### PR TITLE
Change: Link to releases, description of Orochimaru location 

### DIFF
--- a/src/interface/interface.dm
+++ b/src/interface/interface.dm
@@ -791,7 +791,7 @@ client
 
 		Changelog()
 			set hidden=1
-			src << link("https://github.com/illusivebIair/naruto-evolution-community/releases")
+			src << link("https://github.com/IllusiveBIair/naruto-evolution/releases")
 
 		Who()
 			set hidden = 1

--- a/src/items/clan_items.dm
+++ b/src/items/clan_items.dm
@@ -47,7 +47,7 @@ obj
 								usr.client.prompt({"You have gained [src.clan] as your first clan!"}, "[src.name]")
 							src.loc = null
 							usr.client.UpdateInventoryPanel()
-						else usr.client.prompt({"You already have both of your clans. You've heard rumors of a man who might be able to help. He lives in a small village in the south-west of the map."}, "[src.name]")
+						else usr.client.prompt({"You already have both of your clans. You've heard rumors of a man who might be able to help. He lives in a small village in the south-east of the map."}, "[src.name]")
 
 
 			Scripture_of_Lord_Jashin //Jashin clan
@@ -106,7 +106,7 @@ obj
 			verb
 				Use()
 					set src in usr.contents
-					usr.client.prompt({"You have no idea how to use this. You've heard rumors of a man who might be able to help. He lives in a small village in the south-west of the map."}, "[src.name]")
+					usr.client.prompt({"You have no idea how to use this. You've heard rumors of a man who might be able to help. He lives in a small village in the south-east of the map."}, "[src.name]")
 
 			Yuki_Clan_Cells
 				name = "Frozen Cells"


### PR DESCRIPTION
-Changelog button now correctly redirects to Github releases
-Corrected use message on Eyes of Uchiha to say south-east instead of south-west