### PR TITLE
docs: add shields.io badge for license

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,11 @@
 [![Build](https://github.com/illusivebIair/naruto-evolution/actions/workflows/build.yml/badge.svg)](https://github.com/illusivebIair/naruto-evolution/actions/workflows/build.yml)
 [![Release](https://github.com/illusivebIair/naruto-evolution/actions/workflows/release.yml/badge.svg)](https://github.com/illusivebIair/naruto-evolution/actions/workflows/release.yml)
+[![License](https://img.shields.io/github/license/IllusiveBIair/naruto-evolution)](https://github.com/IllusiveBIair/naruto-evolution/blob/main/LICENSE.md)
 
 
 # Naruto Evolution
 
 A fan inspired online game based on the Naruto Universe.
-
-(Licensed under AGPL-3.0-or-later)
 
 ## Setup Development Environment
 


### PR DESCRIPTION
- Add a shields.io badge displaying the license to the README:
![image](https://github.com/IllusiveBIair/naruto-evolution/assets/18235822/5f5affe4-ed9d-4c65-9724-f489074354f3)

- Remove the following text from the README:
> (Licensed under AGPL-3.0-or-later)
