### PR TITLE
build: fix latest tag for docker images

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,6 @@ env:
   BYOND_VERSION: "514.1589"
   REGISTRY: docker.io
   IMAGE_NAME: ${{ secrets.DOCKER_USERNAME }}/naruto-evolution
-  LATEST_MAJOR_VERSION: 2
 
 jobs:
   release:
@@ -46,8 +45,7 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
-          flavor: |
-            latest=${{ startsWith(github.ref, 'refs/tags/${{ env.LATEST_MAJOR_VERSION }}') }}
+            type=raw,value=latest,enable={{is_default_branch}}
       
       - name: Build the Docker image and publish to the Docker Registry
         uses: docker/build-push-action@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,10 +42,10 @@ jobs:
         with:
           images: ${{ env.IMAGE_NAME }}
           tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
-            type=raw,value=latest,enable={{is_default_branch}}
       
       - name: Build the Docker image and publish to the Docker Registry
         uses: docker/build-push-action@v3


### PR DESCRIPTION
This commit fixes the latest tag for docker images.

Going forward, the latest tag `illusiveblair/naruto-evolution:latest` will be updated when you create a release from the default branch. Currently your default branch is `main`, but if you were to ever define a new branch name as default, this policy will automatically apply to the new branch.

![image](https://github.com/IllusiveBIair/naruto-evolution/assets/18235822/d7f2fefd-a5f0-4aa6-8404-1e6622aa563e)

As you can see, when you create a release you can pick a tag for the version, but there is also a target branch. By default it targets your default branch. If the release is based on your default branch, it will publish and update the following tags:

`illusiveblair/naruto-evolution:latest`
`illusiveblair/naruto-evolution:{FULL_VERSION}`
`illusiveblair/naruto-evolution:{MAJOR}.{MINOR}`
`illusiveblair/naruto-evolution:{MAJOR}`

You can then use the tag you prefer for auto updates.

Currently, you are deploying to the latest major version: `illusiveblair/naruto-evolution:2`

So if you version bump to say, version 3.0.0, it will require you to manually remove the docker container on your server and then redeploy with version 3.

Generally version tagging is best practice, but in your case I recommend switching to `illusiveblair/naruto-evolution:latest`. That way you never have to worry about the game not deploying with a major version bump.