### PR TITLE
change: update codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,7 @@
-/.github/ @douglasparker
-/src/database/ @douglasparker
-.gitattributes @douglasparker
-.gitignore @douglasparker
-.gitmodules @douglasparker
-Dockerfile @douglasparker
-VERSION @douglasparker
+/.github/ @IllusiveBIair
+/src/database/ @IllusiveBIair
+.gitattributes @IllusiveBIair
+.gitignore @IllusiveBIair
+.gitmodules @IllusiveBIair
+Dockerfile @IllusiveBIair
+VERSION @IllusiveBIair


### PR DESCRIPTION
This patch makes it so you will always be required to approve changes to files you are designated as the code owner.

I have made you the code owner of important files you want to pay special attention to: be it for security reasons or to avoid breaking changes in the case of `/src/database/`.